### PR TITLE
Update On the Quickstart Backend API for Spring

### DIFF
--- a/01-Authorization/pom.xml
+++ b/01-Authorization/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.4.1.RELEASE</version>
+        <version>2.0.5.RELEASE</version>
         <relativePath/>
     </parent>
 
@@ -46,9 +46,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.auth0</groupId>
-            <artifactId>auth0</artifactId>
-            <version>1.9.1</version>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.1</version>
         </dependency>
 
         <dependency>

--- a/01-Authorization/pom.xml
+++ b/01-Authorization/pom.xml
@@ -40,9 +40,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.auth0</groupId>
-            <artifactId>auth0-spring-security-api</artifactId>
-            <version>1.1.0</version>
+            <groupId>org.springframework.security.oauth.boot</groupId>
+            <artifactId>spring-security-oauth2-autoconfigure</artifactId>
+            <version>2.0.5.RELEASE</version>
         </dependency>
 
         <dependency>

--- a/01-Authorization/src/main/resources/auth0.properties.example
+++ b/01-Authorization/src/main/resources/auth0.properties.example
@@ -1,2 +1,2 @@
-auth0.issuer:https://{DOMAIN}/
-auth0.apiAudience:{API_IDENTIFIER}
+security.oauth2.resource.jwk.keySetUri:https://${DOMAIN}/.well-known/jwks.json
+security.oauth2.resource.id:${API_IDENTIFIER}

--- a/01-Authorization/src/main/resources/auth0.properties.example
+++ b/01-Authorization/src/main/resources/auth0.properties.example
@@ -1,2 +1,2 @@
-security.oauth2.resource.jwk.keySetUri:https://${DOMAIN}/.well-known/jwks.json
-security.oauth2.resource.id:${API_IDENTIFIER}
+security.oauth2.resource.jwk.keySetUri:https://{DOMAIN}/.well-known/jwks.json
+security.oauth2.resource.id:{API_IDENTIFIER}


### PR DESCRIPTION
I updated the Spring Boot version from **1.4.1** to **2.0.5** in order to use Spring OAuth Security for Resource servers. I also removed the Auth0 dependencies from `pom.xml`. Updated `auth0.properties.example` to support values for Spring OAuth. I also updated the AppConfig.java with Spring Security OAuth token validation and endpoint protection code. Is not like the other Quickstart is broken, I just thing we can have both if possible.

