### PR TITLE
Override Jackson and logback versions from Spring Boot BOM

### DIFF
--- a/01-Authorization/build.gradle
+++ b/01-Authorization/build.gradle
@@ -5,11 +5,10 @@ buildscript {
 }
 
 plugins {
-    id 'org.springframework.boot' version '1.5.21.RELEASE'
+    id 'org.springframework.boot' version '1.5.22.RELEASE'
 }
 
-ext['jackson.version'] = '2.9.9'
-ext['logback.version'] = '1.2.3'
+apply plugin: 'io.spring.dependency-management'
 
 group = 'com.auth0'
 version = '0.0.1-SNAPSHOT'
@@ -26,4 +25,11 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.json:json:20180813'
+}
+
+dependencyManagement {
+  imports {
+    mavenBom 'com.fasterxml.jackson:jackson-bom:2.9.9.20190807'
+    mavenBom 'ch.qos.logback:logback-classic:1.2.3'
+  }
 }


### PR DESCRIPTION
- Update to Spring Boot 1.5.22
- Use the [Spring Boot Dependency Plugin](https://docs.spring.io/dependency-management-plugin/docs/current-SNAPSHOT/reference/html/)

See [this issue and posted workaround](https://github.com/spring-projects/spring-boot/issues/17808#issuecomment-520722214) for reference.
