### PR TITLE
Add comment about issues when including a token to permitAll routes

### DIFF
--- a/01-Authorization/src/main/java/com/auth0/example/AppConfig.java
+++ b/01-Authorization/src/main/java/com/auth0/example/AppConfig.java
@@ -43,6 +43,10 @@ public class AppConfig extends WebSecurityConfigurerAdapter {
                 .forRS256(apiAudience, issuer)
                 .configure(http)
                 .authorizeRequests()
+
+                // Note: If passing an Authorization header, Spring Security will validate it even with permitAll()
+                // You can ignore security filters if this is an issue for you, as discussed here:
+                // https://stackoverflow.com/questions/36296869/spring-security-permitall-still-considering-token-passed-in-authorization-header
                 .antMatchers(HttpMethod.GET, "/api/public").permitAll()
                 .antMatchers(HttpMethod.GET, "/api/private").authenticated()
                 .antMatchers(HttpMethod.GET, "/api/private-scoped").hasAuthority("read:messages");


### PR DESCRIPTION
As noted in the added code comment, Spring Security will validate JWTs even if `permitAll` is specified. If this is an issue, it is possible to turn off security filters for routes.

I'm adding a comment instead of changing the code to ignore the `/public` route because turning off security filters is not always the desired result (it makes most sense for static resources, as discussed in the SO thread).

References:
* https://stackoverflow.com/questions/36296869/spring-security-permitall-still-considering-token-passed-in-authorization-header
* https://github.com/spring-projects/spring-security-oauth/issues/1516

Closes #46 